### PR TITLE
chore: disable vsce publish until PAT is configured

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,6 +52,7 @@ jobs:
           files: "*.vsix"
 
       - name: Publish to VS Code Marketplace
+        if: false # Disabled for now
         run: npx vsce publish --no-dependencies
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
Disables the VS Code Marketplace publish step in release workflow.

The `VSCE_PAT` secret needs to be configured before enabling automatic publishing.